### PR TITLE
Implement configurable server and uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,35 @@
-# Project Documentation
-
 # wb Package
 
-The `wb` package is a simple command-line tool that allows users to list the contents of the current directory.
+`wb` is a lightweight web-based file browser built on Tornado. It lets you browse and download files from a directory through a simple web interface protected by an access token.
 
 ## Installation
 
-To install the `wb` package, you can use the following command:
+Run the following command from the project root to install the package and its dependencies:
 
-```
+```bash
 pip install .
 ```
 
-Make sure you run this command in the root directory of the project where the `setup.py` file is located.
-
 ## Usage
 
-Once installed, you can use the package by running:
+Start the server using:
 
-```
-python -m wb
+```bash
+python -m wb [--port PORT] [--dir DIRECTORY]
 ```
 
-This command will list the contents of the current directory in the terminal.
+On startup a one-time access token is printed to the console. Navigate to `http://<host>:<port>/login` and provide this token to gain access. The default port range is 8000-9000 but you can specify a port with the `--port` flag or the `WB_PORT` environment variable. Use `--dir` (or `WB_DIR`) to serve a different directory.
+
+Once logged in you can browse directories, download files and upload new files from the `/upload` page.
+
+## Running Tests
+
+Install development requirements and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pip==25.1.1
 setuptools==80.3.1
 tornado==6.5.1
 wheel==0.45.1
+pytest==8.4.1

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,24 @@
+import os
+from tornado.testing import AsyncHTTPTestCase
+import tornado.web
+
+from wb.main import make_app, ACCESS_TOKEN
+
+class AppTest(AsyncHTTPTestCase):
+    def get_app(self):
+        settings = {
+            "cookie_secret": ACCESS_TOKEN,
+            "login_url": "/login",
+            "root_dir": os.getcwd(),
+        }
+        return make_app(settings)
+
+    def test_login_and_list(self):
+        response = self.fetch('/login', method='POST', body=f'token={ACCESS_TOKEN}', follow_redirects=False)
+        self.assertEqual(response.code, 302)
+        cookie = response.headers.get('Set-Cookie')
+        self.assertIsNotNone(cookie)
+
+        resp2 = self.fetch('/', headers={'Cookie': cookie})
+        self.assertEqual(resp2.code, 200)
+        self.assertIn(b'Directory listing', resp2.body)

--- a/wb/main.py
+++ b/wb/main.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import argparse
 from typing import Optional
 
 import tornado.ioloop
@@ -9,6 +10,12 @@ import socket
 # Generate a random token at startup
 ACCESS_TOKEN = os.environ.get('WB_ACCESS_TOKEN') or secrets.token_urlsafe(32)
 print(f"Access token: {ACCESS_TOKEN}")
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Simple web file browser")
+    parser.add_argument("--port", type=int, help="Port to listen on")
+    parser.add_argument("--dir", help="Directory to serve")
+    return parser.parse_args()
 
 class BaseHandler(tornado.web.RequestHandler):
     def get_current_user(self) -> Optional[str]:
@@ -43,8 +50,8 @@ class LoginHandler(BaseHandler):
 class MainHandler(BaseHandler):
     @tornado.web.authenticated
     def get(self, path):
-        abspath = os.path.abspath(os.path.join(os.getcwd(), path))
-        root = os.getcwd()
+        root = self.application.settings["root_dir"]
+        abspath = os.path.abspath(os.path.join(root, path))
         if not abspath.startswith(root):
             self.set_status(403)
             self.write("Forbidden")
@@ -94,7 +101,9 @@ class MainHandler(BaseHandler):
             </head>
             <body>
             """)
-            self.write("<h2>Directory listing for {}</h2><ul>".format(path or "/"))
+            self.write(f"<h2>Directory listing for {path or '/'} </h2>")
+            self.write('<p><a href="/upload">Upload file</a></p>')
+            self.write("<ul>")
             if path:
                 parent = os.path.dirname(path.rstrip("/"))
                 self.write(f'<li><a href="/{parent}" class="file-link">..</a></li>')
@@ -132,31 +141,64 @@ class MainHandler(BaseHandler):
             self.set_status(404)
             self.write("File not found")
 
+class UploadHandler(BaseHandler):
+    @tornado.web.authenticated
+    def get(self):
+        self.write('''<html><body><h2>Upload File</h2>
+            <form method="POST" enctype="multipart/form-data">
+                <input type="file" name="file">
+                <input type="submit" value="Upload">
+            </form>
+        </body></html>''')
+
+    @tornado.web.authenticated
+    def post(self):
+        if 'file' not in self.request.files:
+            self.write("No file uploaded")
+            return
+        fileinfo = self.request.files['file'][0]
+        filename = os.path.basename(fileinfo['filename'])
+        root = self.application.settings['root_dir']
+        dest = os.path.join(root, filename)
+        with open(dest, 'wb') as f:
+            f.write(fileinfo['body'])
+        self.redirect('/')
+
 def make_app(settings):
-   
+
     return tornado.web.Application([
         (r"/login", LoginHandler),
+        (r"/upload", UploadHandler),
         (r"/(.*)", MainHandler),
     ], **settings)
 
 
 def main():
+    args = parse_args()
+    root_dir = args.dir or os.environ.get("WB_DIR") or os.getcwd()
+    port = args.port or int(os.environ.get("WB_PORT", 0))
+
     settings = {
         "cookie_secret": ACCESS_TOKEN,
         "login_url": "/login",
+        "root_dir": os.path.abspath(root_dir),
     }
+
     app = make_app(settings)
-    port = 8000
-    while port<9000:
+    if port:
+        ports = [port]
+    else:
+        ports = range(8000, 9000)
+
+    for p in ports:
         try:
-            print(settings,port)
-            app.listen(port)
-            print(f"Serving HTTP on 0.0.0.0 port {port} (http://0.0.0.0:{port}/) ...")
-            print(f"http://{socket.getfqdn()}:{port}/")
+            app.listen(p)
+            print(f"Serving HTTP on 0.0.0.0 port {p} (http://0.0.0.0:{p}/) ...")
+            print(f"http://{socket.getfqdn()}:{p}/")
             tornado.ioloop.IOLoop.current().start()
-            
+            break
         except OSError:
-            port+=1
+            continue
     
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- update README with web usage instructions
- add pytest requirement
- implement configurable port/dir and upload handler
- add minimal Tornado test and fix login redirect check

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68827c605bf8832ab4b553b35caaa03b